### PR TITLE
fix(links): add a trailing slash to relative paths

### DIFF
--- a/scripts/popup.js
+++ b/scripts/popup.js
@@ -33,7 +33,7 @@ document.querySelectorAll('.login-button').forEach(node => {
       };
     }).then(user => {
       if (user.isNew) {
-        window.location.href = '/signup';
+        window.location.href = '/signup/';
       } else if (user.school) {
         window.location.href = DASHBOARD_URL;
       }

--- a/src/donate.hbs
+++ b/src/donate.hbs
@@ -8,7 +8,7 @@ prices: [1, 5, 10, 25, 50, 100]
 		<div class="container-sm">
 			<h1>Buy us a coffee?</h1>
 			<p>
-				Gradebook is 100% free for students, but maintaining a service like this is expensive. A donation of just $5 helps our <a href="/team">small team</a> build new features and support thousands of students. Will you consider contributing? 😀
+				Gradebook is 100% free for students, but maintaining a service like this is expensive. A donation of just $5 helps our <a href="/team/">small team</a> build new features and support thousands of students. Will you consider contributing? 😀
 			</p>
 			<div class="text-center m-auto">
 				<form name="donate" id="donate">

--- a/src/layouts/default.hbs
+++ b/src/layouts/default.hbs
@@ -92,9 +92,9 @@
 								<div class="footer-top-links">
 									<div class="footer-title mb-16">About</div>
 									<ul class="list-reset">
-										<li><a href="/blog">Blog</a></li>
-										<li><a href="/team">Our Team</a></li>
-										<li><a href="/donate">Donate</a></li>
+										<li><a href="/blog/">Blog</a></li>
+										<li><a href="/team/">Our Team</a></li>
+										<li><a href="/donate/">Donate</a></li>
 									</ul>
 								</div>
 							</div>
@@ -104,9 +104,9 @@
 								<div class="footer-top-links">
 									<div class="footer-title mb-16">Disclaimers</div>
 									<ul class="list-reset">
-										<li><a href="/terms-of-service">Terms of Service</a></li>
-										<li><a href="/privacy-policy">Privacy Policy</a></li>
-										<li><a href="/security">Security</a></li>
+										<li><a href="/terms-of-service/">Terms of Service</a></li>
+										<li><a href="/privacy-policy/">Privacy Policy</a></li>
+										<li><a href="/security/">Security</a></li>
 									</ul>
 								</div>
 							</div>
@@ -116,8 +116,8 @@
 								<div class="footer-top-links">
 									<div class="footer-title mb-16">Get in Touch</div>
 									<ul class="list-reset">
-										<li><a href="/enterprise">Enterprise Partnerships</a></li>
-										<li><a href="/support">Support</a></li>
+										<li><a href="/enterprise/">Enterprise Partnerships</a></li>
+										<li><a href="/support/">Support</a></li>
 									</ul>
 								</div>
 							</div>

--- a/src/release-notes.md
+++ b/src/release-notes.md
@@ -387,7 +387,7 @@ _Released July 4, 2020 🎇_
 
 ### Features
 
- - Based on your feedback, we've added a toggle to let you choose between entering points-based grades (18/20) and percentage grades (90%). ([blog post](/blog/toggle-percentages-or-points))
+ - Based on your feedback, we've added a toggle to let you choose between entering points-based grades (18/20) and percentage grades (90%). ([blog post](/blog/toggle-percentages-or-points/))
 
  - The app now goes to sleep after you've been gone for a while
 


### PR DESCRIPTION
- Reported by Google
- Our site is configured for all pages to have a trailing slash
- Avoids an extra redirect (/path --> /path/)

Here's the grep I used to find missing paths:
`grep --only-matching -rE 'href="[^"]+"' dist | grep -v -e /\" -e \"[^/] -e /static -e /built`